### PR TITLE
Added view and cell classes for Messages Category Screen on HomeVC

### DIFF
--- a/iMessage-Geet/iMessage-Geet/ViewControllers/HomeViewController.swift
+++ b/iMessage-Geet/iMessage-Geet/ViewControllers/HomeViewController.swift
@@ -30,7 +30,7 @@ class HomeViewController: UIViewController {
         navigationItem.largeTitleDisplayMode = .always
         title = NSLocalizedString("messages_header", comment: "")
 
-        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "CellID")
+        tableView.register(MessageCategoryCell.self, forCellReuseIdentifier: MessageCategoryCell.reuseIdentifier)
         view.addSubview(tableView)
     }
 
@@ -51,9 +51,17 @@ extension HomeViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "CellID", for: indexPath)
-        cell.textLabel?.text = "Message \(indexPath.row + 1)"
+        let cell = tableView.dequeueReusableCell(withIdentifier: MessageCategoryCell.reuseIdentifier, for: indexPath) as! MessageCategoryCell
+        cell.configure(
+            icon: UIImage(systemName: "bubble.left.and.bubble.right")!,
+            title: "All messages",
+            unreadMessagesCount: 2)
         return cell
     }
+
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 50
+    }
+
 }
 

--- a/iMessage-Geet/iMessage-Geet/Views/MessageCategoryCell.swift
+++ b/iMessage-Geet/iMessage-Geet/Views/MessageCategoryCell.swift
@@ -1,0 +1,40 @@
+//  Created by Geetesh Mandaogade on 02/08/25.
+
+import UIKit
+import Foundation
+
+class MessageCategoryCell: UITableViewCell {
+
+    // MARK: - Properties
+
+    static let reuseIdentifier = "MessageCategoryCell"
+    private lazy var messageCategoryView = MessageCategoryView()
+
+    // MARK: - Initializers
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        contentView.addSubview(messageCategoryView)
+        messageCategoryView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            messageCategoryView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            messageCategoryView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            messageCategoryView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            messageCategoryView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Public API
+
+    func configure(icon: UIImage, title: String, unreadMessagesCount: Int?) {
+        messageCategoryView.configureView(
+            with: icon,
+            title: title,
+            unreadMessagesCount: unreadMessagesCount)
+    }
+}

--- a/iMessage-Geet/iMessage-Geet/Views/MessageCategoryView.swift
+++ b/iMessage-Geet/iMessage-Geet/Views/MessageCategoryView.swift
@@ -1,0 +1,93 @@
+//  Created by Geetesh Mandaogade on 02/08/25.
+
+import Foundation
+import UIKit
+
+class MessageCategoryView: UIView {
+
+    // MARK: - Properties
+
+    private lazy var iconImageView: UIImageView = {
+        let iconImageView = UIImageView()
+        iconImageView.translatesAutoresizingMaskIntoConstraints = false
+        return iconImageView
+    }()
+
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private lazy var arrowImageView: UIImageView = {
+        let arrowImageView = UIImageView()
+        arrowImageView.translatesAutoresizingMaskIntoConstraints = false
+        arrowImageView.image = UIImage(systemName: "greaterthan")
+        return arrowImageView
+    }()
+
+    private lazy var unreadMessagesLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 1
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    // MARK: - Initializer
+
+    public init() {
+        super.init(frame: CGRectZero)
+
+        setupViewHierarchy()
+        setupViewConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Public APIs
+
+    func configureView(with iconImage: UIImage,
+                       title: String,
+                       unreadMessagesCount: Int?) {
+        iconImageView.image = iconImage
+        titleLabel.text = title
+        if let unreadMessagesCount {
+            unreadMessagesLabel.text = String(unreadMessagesCount)
+        }
+    }
+
+    // MARK: - Private Helpers
+
+    private func setupViewConstraints() {
+        NSLayoutConstraint.activate([
+            iconImageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            iconImageView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            iconImageView.widthAnchor.constraint(equalToConstant: 30),
+            iconImageView.heightAnchor.constraint(equalToConstant: 20),
+
+            titleLabel.leadingAnchor.constraint(equalTo: iconImageView.trailingAnchor, constant: 12),
+            titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+
+            unreadMessagesLabel.leadingAnchor.constraint(greaterThanOrEqualTo: titleLabel.trailingAnchor, constant: 8),
+            unreadMessagesLabel.trailingAnchor.constraint(equalTo: arrowImageView.leadingAnchor, constant: -8),
+            unreadMessagesLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+
+            arrowImageView.leadingAnchor.constraint(equalTo: unreadMessagesLabel.trailingAnchor, constant: 8),
+            arrowImageView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20),
+            arrowImageView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            arrowImageView.widthAnchor.constraint(equalToConstant: 10),
+            arrowImageView.heightAnchor.constraint(equalToConstant: 20),
+
+        ])
+    }
+
+    private func setupViewHierarchy() {
+        addSubview(iconImageView)
+        addSubview(titleLabel)
+        addSubview(unreadMessagesLabel)
+        addSubview(arrowImageView)
+    }
+}


### PR DESCRIPTION
**Summary:**

This PR adds:
- Cell and view classes that will be used on the Home Screen for Messages Category like All Messages. etc
- Will introduce a proper architecture to add cell data for different types of Message categories along with UI enhancements in an upcoming PR.

**Screenshot:**

Smoke tested the application with some dummy values.

<img width="350" height="760" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-03 at 02 30 10" src="https://github.com/user-attachments/assets/8a4540be-cb09-49dd-9cd8-2e18290de869" />
