### PR TITLE
Integrating classes `MessageCategoryView` and Cell to render all categories Mocked in the `MessageCategoriesMock`

### DIFF
--- a/iMessage-Geet/iMessage-Geet/MockData/MessageCategoriesMock.swift
+++ b/iMessage-Geet/iMessage-Geet/MockData/MessageCategoriesMock.swift
@@ -1,0 +1,112 @@
+//  Created by Geetesh Mandaogade on 03/08/25.
+
+import Foundation
+import UIKit
+
+enum MessageCategoryType: Int {
+    case allMessages
+    case knownSenders
+    case unknownSenders
+    case unread
+
+    case allTransactions
+    case finance
+    case orders
+    case reminders
+    case promotions
+
+    case junk
+    case recentlyDeleted
+}
+
+struct MessageCategory {
+    let type: MessageCategoryType
+    let title: String
+    let iconName: String
+    let unreadCount: Int?
+}
+
+struct MessageSection {
+    let title: String?
+    let categories: [MessageCategory]
+}
+
+class MessageCategoriesMock {
+
+    static let categories: [MessageCategory] = [
+        MessageCategory(type: .allMessages,
+                        title: NSLocalizedString("all_messages_title", comment: ""),
+                        iconName: "bubble",
+                        unreadCount: 7),
+
+        MessageCategory(type: .knownSenders,
+                        title: NSLocalizedString("known_senders_title", comment: ""),
+                        iconName: "person.circle",
+                        unreadCount: 1),
+
+        MessageCategory(type: .unknownSenders,
+                        title: NSLocalizedString("unknown_senders_title", comment: ""),
+                        iconName: "person.crop.circle.badge.questionmark",
+                        unreadCount: 7),
+
+        MessageCategory(type: .unread,
+                        title: NSLocalizedString("unread_messages_title", comment: ""),
+                        iconName: "exclamationmark.bubble",
+                        unreadCount: 3),
+
+        MessageCategory(type: .allTransactions,
+                        title: NSLocalizedString("all_transactions_title", comment: ""),
+                        iconName: "arrow.left.arrow.right",
+                        unreadCount: 4),
+
+        MessageCategory(type: .finance,
+                        title: NSLocalizedString("finance_title", comment: ""),
+                        iconName: "creditcard",
+                        unreadCount: 1),
+
+        MessageCategory(type: .orders,
+                        title: NSLocalizedString("orders_title", comment: ""),
+                        iconName: "shippingbox",
+                        unreadCount: 3),
+
+        MessageCategory(type: .reminders,
+                        title: NSLocalizedString("reminders_title", comment: ""),
+                        iconName: "calendar.badge.clock",
+                        unreadCount: 4),
+
+        MessageCategory(type: .promotions,
+                        title: NSLocalizedString("promotions_title", comment: ""),
+                        iconName: "megaphone",
+                        unreadCount: 4),
+
+        MessageCategory(type: .junk,
+                        title: NSLocalizedString("junk_title", comment: ""),
+                        iconName: "xmark.bin",
+                        unreadCount: 4),
+
+        MessageCategory(type: .recentlyDeleted,
+                        title: NSLocalizedString("recently_deleted_title", comment: ""),
+                        iconName: "trash",
+                        unreadCount: 4),
+    ]
+
+    static let sections: [MessageSection] = [
+        MessageSection(title: nil, categories: [
+             categories[0],
+             categories[1],
+             categories[2],
+             categories[3]
+        ]),
+        MessageSection(title: NSLocalizedString("filtered_by_sms_filter_header", comment: ""), categories: [
+            categories[4],
+            categories[5],
+            categories[6],
+            categories[7],
+            categories[8],
+        ]),
+        MessageSection(title: nil, categories: [
+            categories[9],
+            categories[10],
+        ]),
+    ]
+}

--- a/iMessage-Geet/iMessage-Geet/ViewControllers/HomeViewController.swift
+++ b/iMessage-Geet/iMessage-Geet/ViewControllers/HomeViewController.swift
@@ -7,10 +7,9 @@ class HomeViewController: UIViewController {
     // MARK: - Properties
 
     private lazy var tableView: UITableView = {
-        let tableView = UITableView()
+        let tableView = UITableView(frame: CGRectZero, style: .insetGrouped)
         tableView.separatorStyle = .singleLine
         tableView.backgroundColor = .systemGroupedBackground
-        tableView.separatorColor = .black
         tableView.dataSource = self
         tableView.translatesAutoresizingMaskIntoConstraints = false
         return tableView
@@ -46,22 +45,28 @@ class HomeViewController: UIViewController {
 
 extension HomeViewController: UITableViewDataSource {
 
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return MessageCategoriesMock.sections[section].title
+    }
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return MessageCategoriesMock.sections.count
+    }
+
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 10
+        return MessageCategoriesMock.sections[section].categories.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: MessageCategoryCell.reuseIdentifier, for: indexPath) as! MessageCategoryCell
+        let messageCategory = MessageCategoriesMock.sections[indexPath.section].categories[indexPath.row]
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: MessageCategoryCell.reuseIdentifier, for: indexPath) as? MessageCategoryCell else {
+            return UITableViewCell()
+        }
+
         cell.configure(
-            icon: UIImage(systemName: "bubble.left.and.bubble.right")!,
-            title: "All messages",
-            unreadMessagesCount: 2)
+            icon: UIImage(systemName: messageCategory.iconName),
+            title: messageCategory.title,
+            unreadMessagesCount: messageCategory.unreadCount)
         return cell
     }
-
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 50
-    }
-
 }
-

--- a/iMessage-Geet/iMessage-Geet/Views/MessageCategoryCell.swift
+++ b/iMessage-Geet/iMessage-Geet/Views/MessageCategoryCell.swift
@@ -31,7 +31,9 @@ class MessageCategoryCell: UITableViewCell {
 
     // MARK: - Public API
 
-    func configure(icon: UIImage, title: String, unreadMessagesCount: Int?) {
+    func configure(icon: UIImage?,
+                   title: String,
+                   unreadMessagesCount: Int?) {
         messageCategoryView.configureView(
             with: icon,
             title: title,

--- a/iMessage-Geet/iMessage-Geet/Views/MessageCategoryView.swift
+++ b/iMessage-Geet/iMessage-Geet/Views/MessageCategoryView.swift
@@ -24,12 +24,14 @@ class MessageCategoryView: UIView {
         let arrowImageView = UIImageView()
         arrowImageView.translatesAutoresizingMaskIntoConstraints = false
         arrowImageView.image = UIImage(systemName: "greaterthan")
+        arrowImageView.tintColor = .gray
         return arrowImageView
     }()
 
     private lazy var unreadMessagesLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 1
+        label.textColor = .gray
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
@@ -49,14 +51,18 @@ class MessageCategoryView: UIView {
 
     // MARK: - Public APIs
 
-    func configureView(with iconImage: UIImage,
+    func configureView(with iconImage: UIImage?,
                        title: String,
                        unreadMessagesCount: Int?) {
-        iconImageView.image = iconImage
-        titleLabel.text = title
+        if let iconImage {
+            iconImageView.image = iconImage
+        }
+
         if let unreadMessagesCount {
             unreadMessagesLabel.text = String(unreadMessagesCount)
         }
+
+        titleLabel.text = title
     }
 
     // MARK: - Private Helpers
@@ -65,7 +71,7 @@ class MessageCategoryView: UIView {
         NSLayoutConstraint.activate([
             iconImageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
             iconImageView.centerYAnchor.constraint(equalTo: centerYAnchor),
-            iconImageView.widthAnchor.constraint(equalToConstant: 30),
+            iconImageView.widthAnchor.constraint(equalToConstant: 20),
             iconImageView.heightAnchor.constraint(equalToConstant: 20),
 
             titleLabel.leadingAnchor.constraint(equalTo: iconImageView.trailingAnchor, constant: 12),
@@ -80,7 +86,6 @@ class MessageCategoryView: UIView {
             arrowImageView.centerYAnchor.constraint(equalTo: centerYAnchor),
             arrowImageView.widthAnchor.constraint(equalToConstant: 10),
             arrowImageView.heightAnchor.constraint(equalToConstant: 20),
-
         ])
     }
 


### PR DESCRIPTION
### **Summary:**

- Integrated the UI class `MessageCategoryView` and cell to render all categories Mocked in the `MessageCategoriesMock`
- Created a mock class - `MessageCategoriesMock.swift` to hold all the static data for the Home ViewController
- Updated table view properties to match the `iMessage` UI more accurately 
- Added support to reuse the cell class for all types of Message Categories Also used appropriate delegate methods to separate the categories section wise

### **Screenshots:**

Smoke tested the application for both light and dark modes

| Light Mode | Dark Mode |
| -- | -- |
| <img width="350" height="760" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-03 at 14 50 41" src="https://github.com/user-attachments/assets/128119e4-bb6a-4473-8858-46d62920715c" /> | <img width="350" height="760" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-03 at 14 50 46" src="https://github.com/user-attachments/assets/ffe44cb7-5b18-4235-b41f-1689e8952e6c" />|
