### PR TITLE
Renaming changes and new localized strings for upcoming UI

### DIFF
--- a/iMessage-Geet/iMessage-Geet/BaseFolder/Base.lproj/Main.storyboard
+++ b/iMessage-Geet/iMessage-Geet/BaseFolder/Base.lproj/Main.storyboard
@@ -8,10 +8,10 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Home View Controller-->
+        <!--Message Categories View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="HomeViewController" customModule="iMessage_Geet" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="MessageCategoriesViewController" customModule="iMessage_Geet" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/iMessage-Geet/iMessage-Geet/BaseFolder/SceneDelegate.swift
+++ b/iMessage-Geet/iMessage-Geet/BaseFolder/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let window = window else { return }
 
-        let viewController = HomeViewController()
+        let viewController = MessageCategoriesViewController()
         let navigationViewController = UINavigationController(rootViewController: viewController)
         window.rootViewController = navigationViewController
         window.makeKeyAndVisible()

--- a/iMessage-Geet/iMessage-Geet/Localization/de.lproj/Localizable.strings
+++ b/iMessage-Geet/iMessage-Geet/Localization/de.lproj/Localizable.strings
@@ -1,6 +1,6 @@
 // Created by Geetesh Mandaogade on 15/06/25.
 
-// MARK: - HomeViewController
+// MARK: - MessageCategoriesViewController
 
 /* Main title */
 "messages_title" = "Nachrichten";
@@ -22,3 +22,8 @@
 /* Bottom section titles */
 "junk_title" = "Spam";
 "recently_deleted_title" = "Zuletzt gelöscht";
+
+// MARK: - Zero state
+
+"zero_state_title_no_messages" = "Keine Nachrichten";
+"zero_state_subtitle_no_messages" = "Nachrichten, die Sie senden oder empfangen, werden hier angezeigt.";

--- a/iMessage-Geet/iMessage-Geet/Localization/en.lproj/Localizable.strings
+++ b/iMessage-Geet/iMessage-Geet/Localization/en.lproj/Localizable.strings
@@ -1,6 +1,6 @@
 // Created by Geetesh Mandaogade on 15/06/25.
 
-// MARK: - HomeViewController
+// MARK: - MessageCategoriesViewController
 
 /* Main title */
 "messages_header" = "Messages";
@@ -22,3 +22,8 @@
 /* Bottom section titles */
 "junk_title" = "Junk";
 "recently_deleted_title" = "Recently Deleted";
+
+// MARK: - Zero state
+
+"zero_state_title_no_messages" = "No Messages";
+"zero_state_subtitle_no_messages" = "Messages you send or receive will appear here.";

--- a/iMessage-Geet/iMessage-Geet/ViewControllers/MessageCategoriesViewController.swift
+++ b/iMessage-Geet/iMessage-Geet/ViewControllers/MessageCategoriesViewController.swift
@@ -29,7 +29,9 @@ class HomeViewController: UIViewController {
         navigationItem.largeTitleDisplayMode = .always
         title = NSLocalizedString("messages_header", comment: "")
 
-        tableView.register(MessageCategoryCell.self, forCellReuseIdentifier: MessageCategoryCell.reuseIdentifier)
+        tableView.register(
+            MessageCategoryCell.self,
+            forCellReuseIdentifier: MessageCategoryCell.reuseIdentifier)
         view.addSubview(tableView)
     }
 


### PR DESCRIPTION
## Summary:

- Renamed HomeViewController to MessageCategoriesViewController for better clarity.
- Added new strings for ZeroStateView (introducing in a follow up PR).
- Slight change about line limit for readability.

## Testing:
- Built locally.
- No major changes on UI or data part