### PR TITLE
Added `ZeroMessagesStateView` , `MessagesListViewController` and `SpacingConstants` and integrated all these according to the updated mocks

### DIFF
--- a/iMessage-Geet/iMessage-Geet/Localization/de.lproj/Localizable.strings
+++ b/iMessage-Geet/iMessage-Geet/Localization/de.lproj/Localizable.strings
@@ -26,4 +26,15 @@
 // MARK: - Zero state
 
 "zero_state_title_no_messages" = "Keine Nachrichten";
-"zero_state_subtitle_no_messages" = "Nachrichten, die Sie senden oder empfangen, werden hier angezeigt.";
+
+"zero_state_subtitle_all_messages" = "Nachrichten, die Sie senden oder empfangen, werden hier angezeigt.";
+"zero_state_subtitle_known_senders" = "Nachrichten von und an bekannte Absender werden hier angezeigt.";
+"zero_state_subtitle_unknown_senders" = "Nachrichten von unbekannten Absendern werden hier angezeigt.";
+"zero_state_subtitle_unread_messages" = "Ungelesene Nachrichten werden hier angezeigt.";
+"zero_state_subtitle_all_transactions" = "Nachrichten, die als Transaktionen gefiltert wurden, werden hier angezeigt.";
+"zero_state_subtitle_finance" = "Nachrichten, die als Finanzen gefiltert wurden, werden hier angezeigt.";
+"zero_state_subtitle_orders" = "Nachrichten, die als Bestellungen gefiltert wurden, werden hier angezeigt.";
+"zero_state_subtitle_reminders" = "Nachrichten, die als Erinnerungen gefiltert wurden, werden hier angezeigt.";
+"zero_state_subtitle_promotions" = "Nachrichten, die als Werbung gefiltert wurden, werden hier angezeigt.";
+"zero_state_subtitle_junk" = "Nachrichten, die als Spam gefiltert wurden, werden hier angezeigt.";
+"zero_state_subtitle_deleted" = "Unterhaltungen zeigen die verbleibenden Tage bis zur Löschung an. Danach werden die Nachrichten endgültig gelöscht. Dies kann bis zu 40 Tage dauern.";

--- a/iMessage-Geet/iMessage-Geet/Localization/en.lproj/Localizable.strings
+++ b/iMessage-Geet/iMessage-Geet/Localization/en.lproj/Localizable.strings
@@ -26,4 +26,15 @@
 // MARK: - Zero state
 
 "zero_state_title_no_messages" = "No Messages";
-"zero_state_subtitle_no_messages" = "Messages you send or receive will appear here.";
+
+"zero_state_subtitle_all_messages" = "Messages you send or receive will appear here.";
+"zero_state_subtitle_known_senders" = "Messages to and from known senders will appear here.";
+"zero_state_subtitle_unknown_senders" = "Messages from unknown senders will appear here.";
+"zero_state_subtitle_unread_messages" = "Messages that are unread will appear here.";
+"zero_state_subtitle_all_transactions" = "Messages filtered as transactions will appear here.";
+"zero_state_subtitle_finance" = "Messages filtered as Finance will appear here.";
+"zero_state_subtitle_orders" = "Messages filtered as Orders will appear here.";
+"zero_state_subtitle_reminders" = "Messages filtered as Reminders will appear here.";
+"zero_state_subtitle_promotions" = "Messages filtered as Promotions will appear here.";
+"zero_state_subtitle_junk" = "Messages filtered as junk will appear here.";
+"zero_state_subtitle_deleted" = "Conversations show the days remaining before deletion. After that time, messages will be permanently deleted. This may take up to 40 days.";

--- a/iMessage-Geet/iMessage-Geet/MockData/MessageCategoriesMock.swift
+++ b/iMessage-Geet/iMessage-Geet/MockData/MessageCategoriesMock.swift
@@ -1,6 +1,5 @@
 //  Created by Geetesh Mandaogade on 03/08/25.
 
-import Foundation
 import UIKit
 
 enum MessageCategoryType: Int {
@@ -24,6 +23,8 @@ struct MessageCategory {
     let title: String
     let iconName: String
     let unreadCount: Int?
+    let totalMessagesCount: Int
+    let categoryDescription: String
 }
 
 struct MessageSection {
@@ -37,57 +38,79 @@ class MessageCategoriesMock {
         MessageCategory(type: .allMessages,
                         title: NSLocalizedString("all_messages_title", comment: ""),
                         iconName: "bubble",
-                        unreadCount: 7),
+                        unreadCount: 7,
+                        totalMessagesCount: 0,
+                        categoryDescription: NSLocalizedString("zero_state_subtitle_all_messages", comment: "")),
 
         MessageCategory(type: .knownSenders,
                         title: NSLocalizedString("known_senders_title", comment: ""),
                         iconName: "person.circle",
-                        unreadCount: 1),
+                        unreadCount: 1,
+                        totalMessagesCount: 0,
+                        categoryDescription: NSLocalizedString("zero_state_subtitle_known_senders", comment: "")),
 
         MessageCategory(type: .unknownSenders,
                         title: NSLocalizedString("unknown_senders_title", comment: ""),
                         iconName: "person.crop.circle.badge.questionmark",
-                        unreadCount: 7),
+                        unreadCount: 7,
+                        totalMessagesCount: 0,
+                        categoryDescription: NSLocalizedString("zero_state_subtitle_unknown_senders", comment: "")),
 
         MessageCategory(type: .unread,
                         title: NSLocalizedString("unread_messages_title", comment: ""),
                         iconName: "exclamationmark.bubble",
-                        unreadCount: 3),
+                        unreadCount: 3,
+                        totalMessagesCount: 0,
+                        categoryDescription: NSLocalizedString("zero_state_subtitle_unread_messages", comment: "")),
 
         MessageCategory(type: .allTransactions,
                         title: NSLocalizedString("all_transactions_title", comment: ""),
                         iconName: "arrow.left.arrow.right",
-                        unreadCount: 4),
+                        unreadCount: 4,
+                        totalMessagesCount: 0,
+                        categoryDescription: NSLocalizedString("zero_state_subtitle_all_transactions", comment: "")),
 
         MessageCategory(type: .finance,
                         title: NSLocalizedString("finance_title", comment: ""),
                         iconName: "creditcard",
-                        unreadCount: 1),
+                        unreadCount: 1,
+                        totalMessagesCount: 0,
+                        categoryDescription: NSLocalizedString("zero_state_subtitle_finance", comment: "")),
 
         MessageCategory(type: .orders,
                         title: NSLocalizedString("orders_title", comment: ""),
                         iconName: "shippingbox",
-                        unreadCount: 3),
+                        unreadCount: 3,
+                        totalMessagesCount: 0,
+                        categoryDescription: NSLocalizedString("zero_state_subtitle_orders", comment: "")),
 
         MessageCategory(type: .reminders,
                         title: NSLocalizedString("reminders_title", comment: ""),
                         iconName: "calendar.badge.clock",
-                        unreadCount: 4),
+                        unreadCount: 4,
+                        totalMessagesCount: 0,
+                        categoryDescription: NSLocalizedString("zero_state_subtitle_reminders", comment: "")),
 
         MessageCategory(type: .promotions,
                         title: NSLocalizedString("promotions_title", comment: ""),
                         iconName: "megaphone",
-                        unreadCount: 4),
+                        unreadCount: 4,
+                        totalMessagesCount: 0,
+                        categoryDescription: NSLocalizedString("zero_state_subtitle_promotions", comment: "")),
 
         MessageCategory(type: .junk,
                         title: NSLocalizedString("junk_title", comment: ""),
                         iconName: "xmark.bin",
-                        unreadCount: 4),
+                        unreadCount: 4,
+                        totalMessagesCount: 0,
+                        categoryDescription: NSLocalizedString("zero_state_subtitle_junk", comment: "")),
 
         MessageCategory(type: .recentlyDeleted,
                         title: NSLocalizedString("recently_deleted_title", comment: ""),
                         iconName: "trash",
-                        unreadCount: 4),
+                        unreadCount: 4,
+                        totalMessagesCount: 0,
+                        categoryDescription: NSLocalizedString("zero_state_subtitle_deleted", comment: "")),
     ]
 
     static let sections: [MessageSection] = [

--- a/iMessage-Geet/iMessage-Geet/Utils/SpacingConstants.swift
+++ b/iMessage-Geet/iMessage-Geet/Utils/SpacingConstants.swift
@@ -1,0 +1,20 @@
+//  Created by Geetesh Mandaogade on 09/08/25.
+
+import Foundation
+
+class SpacingConstants: NSObject {
+
+    static let spacingQuarterX: CGFloat = 4.0
+
+    static let spacingHalfX: CGFloat = 8.0
+
+    static let spacingOneX: CGFloat = 16.0
+
+    static let spacingOneAndHalfX: CGFloat = 24.0
+
+    static let spacingTwoX: CGFloat = 32.0
+
+    static let spacingThreeX: CGFloat = 48.0
+
+    static let spacingFourX: CGFloat = 64.0
+}

--- a/iMessage-Geet/iMessage-Geet/ViewControllers/MessageCategoriesViewController.swift
+++ b/iMessage-Geet/iMessage-Geet/ViewControllers/MessageCategoriesViewController.swift
@@ -2,7 +2,7 @@
 
 import UIKit
 
-class HomeViewController: UIViewController {
+class MessageCategoriesViewController: UIViewController, UITableViewDelegate {
 
     // MARK: - Properties
 
@@ -12,6 +12,7 @@ class HomeViewController: UIViewController {
         tableView.backgroundColor = .systemGroupedBackground
         tableView.dataSource = self
         tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.delegate = self
         return tableView
     }()
 
@@ -45,7 +46,7 @@ class HomeViewController: UIViewController {
     }
 }
 
-extension HomeViewController: UITableViewDataSource {
+extension MessageCategoriesViewController: UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         return MessageCategoriesMock.sections[section].title
@@ -70,5 +71,15 @@ extension HomeViewController: UITableViewDataSource {
             title: messageCategory.title,
             unreadMessagesCount: messageCategory.unreadCount)
         return cell
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let messageCategory = MessageCategoriesMock.sections[indexPath.section].categories[indexPath.row]
+
+        let newViewController = MessagesListViewController(
+            title: messageCategory.title,
+            totalMessagesCount: messageCategory.totalMessagesCount,
+            categoryDescription: messageCategory.categoryDescription)
+        navigationController?.pushViewController(newViewController, animated: true)
     }
 }

--- a/iMessage-Geet/iMessage-Geet/ViewControllers/MessagesListViewController.swift
+++ b/iMessage-Geet/iMessage-Geet/ViewControllers/MessagesListViewController.swift
@@ -1,0 +1,74 @@
+//  Created by Geetesh Mandaogade on 09/08/25.
+
+import UIKit
+
+class MessagesListViewController: UIViewController {
+
+    // MARK: - Properties
+
+    private let totalMessagesCount: Int
+    private let categoryDescription: String
+
+    private lazy var zeroMessagesStateView: ZeroMessagesStateView = {
+        let view = ZeroMessagesStateView()
+        view.isHidden = true
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    // MARK: - Initializer
+
+    public init(title: String, totalMessagesCount: Int, categoryDescription: String) {
+        self.totalMessagesCount = totalMessagesCount
+        self.categoryDescription = categoryDescription
+
+        super.init(nibName: nil, bundle: nil)
+        self.title = title
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Overriden Methods
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        stylizeView()
+        setupViewHierarchy()
+        setupViews()
+        setupViewConstraints()
+    }
+
+    // MARK: - Private helpers
+
+    private func stylizeView() {
+        view.backgroundColor = .systemBackground
+    }
+
+    private func setupViewHierarchy() {
+        view.addSubview(zeroMessagesStateView)
+    }
+
+    private func setupViews() {
+        if totalMessagesCount == 0 {
+            zeroMessagesStateView.isHidden = false
+            zeroMessagesStateView.configure(categoryDescription: categoryDescription)
+        }
+    }
+
+    private func setupViewConstraints() {
+        var constraints: [NSLayoutConstraint] = []
+        if totalMessagesCount == 0 {
+            constraints.append(zeroMessagesStateView.centerYAnchor.constraint(equalTo: view.centerYAnchor))
+            constraints.append(zeroMessagesStateView.centerXAnchor.constraint(equalTo: view.centerXAnchor))
+
+            constraints.append(zeroMessagesStateView.topAnchor.constraint(greaterThanOrEqualTo: view.topAnchor))
+            constraints.append(zeroMessagesStateView.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor))
+            constraints.append(zeroMessagesStateView.bottomAnchor.constraint(lessThanOrEqualTo: view.bottomAnchor))
+            constraints.append(zeroMessagesStateView.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor))
+        }
+        NSLayoutConstraint.activate(constraints)
+    }
+}

--- a/iMessage-Geet/iMessage-Geet/Views/MessageCategoryCell.swift
+++ b/iMessage-Geet/iMessage-Geet/Views/MessageCategoryCell.swift
@@ -1,7 +1,6 @@
 //  Created by Geetesh Mandaogade on 02/08/25.
 
 import UIKit
-import Foundation
 
 class MessageCategoryCell: UITableViewCell {
 
@@ -15,6 +14,16 @@ class MessageCategoryCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
 
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Private Helpers
+
+    private func setupView() {
         contentView.addSubview(messageCategoryView)
         messageCategoryView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -23,10 +32,6 @@ class MessageCategoryCell: UITableViewCell {
             messageCategoryView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             messageCategoryView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
         ])
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
     }
 
     // MARK: - Public API

--- a/iMessage-Geet/iMessage-Geet/Views/MessageCategoryView.swift
+++ b/iMessage-Geet/iMessage-Geet/Views/MessageCategoryView.swift
@@ -1,6 +1,5 @@
 //  Created by Geetesh Mandaogade on 02/08/25.
 
-import Foundation
 import UIKit
 
 class MessageCategoryView: UIView {
@@ -69,23 +68,39 @@ class MessageCategoryView: UIView {
 
     private func setupViewConstraints() {
         NSLayoutConstraint.activate([
-            iconImageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            iconImageView.leadingAnchor.constraint(
+                equalTo: leadingAnchor,
+                constant: SpacingConstants.spacingOneX),
             iconImageView.centerYAnchor.constraint(equalTo: centerYAnchor),
-            iconImageView.widthAnchor.constraint(equalToConstant: 20),
-            iconImageView.heightAnchor.constraint(equalToConstant: 20),
+            iconImageView.widthAnchor.constraint(
+                equalToConstant: SpacingConstants.spacingOneX + SpacingConstants.spacingQuarterX),
+            iconImageView.heightAnchor.constraint(
+                equalToConstant: SpacingConstants.spacingOneX + SpacingConstants.spacingQuarterX),
 
-            titleLabel.leadingAnchor.constraint(equalTo: iconImageView.trailingAnchor, constant: 12),
+            titleLabel.leadingAnchor.constraint(
+                equalTo: iconImageView.trailingAnchor,
+                constant: SpacingConstants.spacingOneX - SpacingConstants.spacingQuarterX),
             titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
 
-            unreadMessagesLabel.leadingAnchor.constraint(greaterThanOrEqualTo: titleLabel.trailingAnchor, constant: 8),
-            unreadMessagesLabel.trailingAnchor.constraint(equalTo: arrowImageView.leadingAnchor, constant: -8),
+            unreadMessagesLabel.leadingAnchor.constraint(
+                greaterThanOrEqualTo: titleLabel.trailingAnchor,
+                constant: SpacingConstants.spacingHalfX),
+            unreadMessagesLabel.trailingAnchor.constraint(
+                equalTo: arrowImageView.leadingAnchor,
+                constant: -SpacingConstants.spacingHalfX),
             unreadMessagesLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
 
-            arrowImageView.leadingAnchor.constraint(equalTo: unreadMessagesLabel.trailingAnchor, constant: 8),
-            arrowImageView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20),
+            arrowImageView.leadingAnchor.constraint(
+                equalTo: unreadMessagesLabel.trailingAnchor,
+                constant: SpacingConstants.spacingHalfX),
+            arrowImageView.trailingAnchor.constraint(
+                equalTo: trailingAnchor,
+                constant: SpacingConstants.spacingQuarterX - SpacingConstants.spacingOneAndHalfX),
             arrowImageView.centerYAnchor.constraint(equalTo: centerYAnchor),
-            arrowImageView.widthAnchor.constraint(equalToConstant: 10),
-            arrowImageView.heightAnchor.constraint(equalToConstant: 20),
+            arrowImageView.widthAnchor.constraint(
+                equalToConstant: SpacingConstants.spacingHalfX + (SpacingConstants.spacingQuarterX/2)),
+            arrowImageView.heightAnchor.constraint(
+                equalToConstant: SpacingConstants.spacingOneX + SpacingConstants.spacingQuarterX),
         ])
     }
 

--- a/iMessage-Geet/iMessage-Geet/Views/ZeroMessagesStateView.swift
+++ b/iMessage-Geet/iMessage-Geet/Views/ZeroMessagesStateView.swift
@@ -1,0 +1,101 @@
+//  Created by Geetesh Mandaogade on 09/08/25.
+
+import UIKit
+
+class ZeroMessagesStateView: UIView {
+
+    // MARK: - Properties
+
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 1
+        label.font = UIFont(
+            name: "HelveticaNeue-Medium",
+            size: SpacingConstants.spacingOneX + SpacingConstants.spacingQuarterX)
+        label.text = NSLocalizedString("zero_state_title_no_messages", comment: "")
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private lazy var subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 0
+        label.font = UIFont.systemFont(
+            ofSize: SpacingConstants.spacingOneX - (SpacingConstants.spacingQuarterX / 2))
+        label.textColor = .gray
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textAlignment = .center
+        return label
+    }()
+
+    private lazy var imageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(systemName: "bubble.fill")
+        imageView.tintColor = .gray
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+
+
+    // MARK: - Overriden Methods
+
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        setupView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Private helpers
+
+    private func setupView() {
+        addSubview(imageView)
+        addSubview(titleLabel)
+        addSubview(subtitleLabel)
+
+        var constraints: [NSLayoutConstraint] = []
+        constraints.append(titleLabel.topAnchor.constraint(
+            equalTo: imageView.bottomAnchor,
+            constant: SpacingConstants.spacingHalfX))
+        constraints.append(subtitleLabel.topAnchor.constraint(
+            equalTo: titleLabel.bottomAnchor,
+            constant: SpacingConstants.spacingQuarterX))
+
+        constraints.append(imageView.widthAnchor.constraint(
+            equalToConstant: SpacingConstants.spacingOneAndHalfX + SpacingConstants.spacingTwoX))
+        constraints.append(imageView.heightAnchor.constraint(equalToConstant: SpacingConstants.spacingThreeX))
+
+        constraints.append(imageView.centerXAnchor.constraint(equalTo: titleLabel.centerXAnchor))
+        constraints.append(titleLabel.centerXAnchor.constraint(equalTo: subtitleLabel.centerXAnchor))
+        constraints.append(imageView.centerXAnchor.constraint(equalTo: centerXAnchor))
+
+        constraints.append(imageView.leadingAnchor.constraint(
+            greaterThanOrEqualTo: leadingAnchor,
+            constant: SpacingConstants.spacingOneX))
+        constraints.append(titleLabel.leadingAnchor.constraint(
+            greaterThanOrEqualTo: leadingAnchor,
+            constant: SpacingConstants.spacingOneX))
+        constraints.append(subtitleLabel.leadingAnchor.constraint(
+            greaterThanOrEqualTo: leadingAnchor,
+            constant: SpacingConstants.spacingOneX))
+        constraints.append(imageView.trailingAnchor.constraint(
+            lessThanOrEqualTo: trailingAnchor,
+            constant: -SpacingConstants.spacingOneX))
+        constraints.append(titleLabel.trailingAnchor.constraint(
+            lessThanOrEqualTo: trailingAnchor,
+            constant: -SpacingConstants.spacingOneX))
+        constraints.append(subtitleLabel.trailingAnchor.constraint(
+            lessThanOrEqualTo: trailingAnchor,
+            constant: -SpacingConstants.spacingOneX))
+        NSLayoutConstraint.activate(constraints)
+    }
+
+    // MARK: - Public functions
+
+    public func configure(categoryDescription: String) {
+        subtitleLabel.text = categoryDescription
+    }
+}


### PR DESCRIPTION
## Summary:

- Created a utils class - `SpacingConstants` for a cleaner use of `CGFloats` across the project and maintain readability
- Added `categoryDescription` for every message category. This string would primarily be used for subtitle labels on zero state view of a particular category
- Added `totalMessageCount` for each message category. This would be used to hold information on how many messages a category currently has.
- Updated the mock data class to hold some hard coded values for both `categoryDescription` & `totalMessageCount`.
- Introduced a new `MessagesListViewController` - for displaying list of messages under a selected category from `MessageCategoriesViewController`
- Currently this new controller holds logic to show a `ZeroMessagesStateView` if `totalMessageCount == 0` for a particular category.
- Introduced new `ZeroMessagesStateView` for conditions where the list of messages under a category is empty.
- Added interaction for tableViewCells using `didSelectRowAt` - pushing the new view controller `MessagesListViewController`
- Added new strings required for the Zero Messages State View

## Testing:

- Tested with the mock data updated in these changes itself.
- Please ignore the illogical mocks that would say that a message category has 7 visited message but shows zero state when opened 😂 --will revisit the mock data in the later stage

| After |
| -- |
| <img src="https://github.com/user-attachments/assets/f11a54c0-33f3-4373-b05e-bdbef7834646" width="300" /> |