### PR TITLE
[Fix] Table view cell looks “stuck” in its selected state after coming back to the Categories/Filter screen:

### DIFF
--- a/iMessage-Geet/iMessage-Geet/ViewControllers/MessageCategoriesViewController.swift
+++ b/iMessage-Geet/iMessage-Geet/ViewControllers/MessageCategoriesViewController.swift
@@ -74,6 +74,7 @@ extension MessageCategoriesViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
         let messageCategory = MessageCategoriesMock.sections[indexPath.section].categories[indexPath.row]
 
         let newViewController = MessagesListViewController(


### PR DESCRIPTION
## Summary:

**Issue:** Table view cell looks “stuck” in its selected state after coming back to the Categories/Filter screen:

**Fix:**
- Added implementation to `deselect` tableView cell just after it was activated.




| Before | After |
| -- | -- |
| <img src="https://github.com/user-attachments/assets/915d8ee1-5387-4f41-8ab4-d4ac91aa99aa" width="300" /> | <img src="https://github.com/user-attachments/assets/5579d804-f8bd-40a8-998e-e8f2e58155c9" width="300" /> |

