### PR TITLE
Added Navigation bar items for `MessagesListViewController` along with minor UI enhacements

### DIFF
--- a/iMessage-Geet/iMessage-Geet/Localization/de.lproj/Localizable.strings
+++ b/iMessage-Geet/iMessage-Geet/Localization/de.lproj/Localizable.strings
@@ -38,3 +38,7 @@
 "zero_state_subtitle_promotions" = "Nachrichten, die als Werbung gefiltert wurden, werden hier angezeigt.";
 "zero_state_subtitle_junk" = "Nachrichten, die als Spam gefiltert wurden, werden hier angezeigt.";
 "zero_state_subtitle_deleted" = "Unterhaltungen zeigen die verbleibenden Tage bis zur Löschung an. Danach werden die Nachrichten endgültig gelöscht. Dies kann bis zu 40 Tage dauern.";
+
+// MARK: - MessagesListViewController
+
+"list_vc_nav_bar_left_button_title" = "Filter";

--- a/iMessage-Geet/iMessage-Geet/Localization/en.lproj/Localizable.strings
+++ b/iMessage-Geet/iMessage-Geet/Localization/en.lproj/Localizable.strings
@@ -38,3 +38,7 @@
 "zero_state_subtitle_promotions" = "Messages filtered as Promotions will appear here.";
 "zero_state_subtitle_junk" = "Messages filtered as junk will appear here.";
 "zero_state_subtitle_deleted" = "Conversations show the days remaining before deletion. After that time, messages will be permanently deleted. This may take up to 40 days.";
+
+// MARK: - MessagesListViewController
+
+"list_vc_nav_bar_left_button_title" = "Filters";

--- a/iMessage-Geet/iMessage-Geet/ViewControllers/MessagesListViewController.swift
+++ b/iMessage-Geet/iMessage-Geet/ViewControllers/MessagesListViewController.swift
@@ -16,6 +16,37 @@ class MessagesListViewController: UIViewController {
         return view
     }()
 
+    private lazy var leftBarBackButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle(NSLocalizedString("list_vc_nav_bar_left_button_title", comment: ""), for: .normal)
+        button.setImage(UIImage(systemName: "chevron.backward"), for: .normal)
+        button.addTarget(self, action: #selector(leftBarButtonTapped), for: .touchUpInside)
+        return button
+    }()
+
+    private lazy var rightBarMoreOptions: UIButton = {
+        let button = UIButton(type: .system)
+        button.setImage(UIImage(systemName: "ellipsis.circle"), for: .normal)
+        button.addTarget(self, action: #selector(rightBarMoreOptionsTapped), for: .touchUpInside)
+        return button
+    }()
+
+    private lazy var rightBarNewMessageButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setImage(UIImage(systemName: "square.and.pencil.circle"), for: .normal)
+        button.addTarget(self, action: #selector(rightBarNewMessageButtonTapped), for: .touchUpInside)
+        return button
+    }()
+
+    private lazy var rightBarButtonStack: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [rightBarMoreOptions, rightBarNewMessageButton])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.spacing = SpacingConstants.spacingOneAndHalfX
+        stackView.axis = .horizontal
+        stackView.alignment = .bottom
+        return stackView
+    }()
+
     // MARK: - Initializer
 
     public init(title: String, totalMessagesCount: Int, categoryDescription: String) {
@@ -39,6 +70,7 @@ class MessagesListViewController: UIViewController {
         setupViewHierarchy()
         setupViews()
         setupViewConstraints()
+        setupNavigationBar()
     }
 
     // MARK: - Private helpers
@@ -70,5 +102,27 @@ class MessagesListViewController: UIViewController {
             constraints.append(zeroMessagesStateView.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor))
         }
         NSLayoutConstraint.activate(constraints)
+    }
+
+    private func setupNavigationBar() {
+        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: leftBarBackButton)
+        navigationItem.rightBarButtonItem = UIBarButtonItem(customView: rightBarButtonStack)
+    }
+
+    @objc
+    func leftBarButtonTapped() {
+        navigationController?.popViewController(animated: true)
+    }
+
+    @objc
+    func rightBarMoreOptionsTapped() {
+        // no-op
+        print("##GM: inside rightBarMoreOptionsTapped")
+    }
+
+    @objc
+    func rightBarNewMessageButtonTapped() {
+        // no-op
+        print("##GM: inside rightBarNewMessageButtonTapped")
     }
 }

--- a/iMessage-Geet/iMessage-Geet/Views/MessageCategoryView.swift
+++ b/iMessage-Geet/iMessage-Geet/Views/MessageCategoryView.swift
@@ -22,7 +22,7 @@ class MessageCategoryView: UIView {
     private lazy var arrowImageView: UIImageView = {
         let arrowImageView = UIImageView()
         arrowImageView.translatesAutoresizingMaskIntoConstraints = false
-        arrowImageView.image = UIImage(systemName: "greaterthan")
+        arrowImageView.image = UIImage(systemName: "chevron.forward")
         arrowImageView.tintColor = .gray
         return arrowImageView
     }()
@@ -97,10 +97,6 @@ class MessageCategoryView: UIView {
                 equalTo: trailingAnchor,
                 constant: SpacingConstants.spacingQuarterX - SpacingConstants.spacingOneAndHalfX),
             arrowImageView.centerYAnchor.constraint(equalTo: centerYAnchor),
-            arrowImageView.widthAnchor.constraint(
-                equalToConstant: SpacingConstants.spacingHalfX + (SpacingConstants.spacingQuarterX/2)),
-            arrowImageView.heightAnchor.constraint(
-                equalToConstant: SpacingConstants.spacingOneX + SpacingConstants.spacingQuarterX),
         ])
     }
 

--- a/iMessage-Geet/iMessage-Geet/Views/ZeroMessagesStateView.swift
+++ b/iMessage-Geet/iMessage-Geet/Views/ZeroMessagesStateView.swift
@@ -30,7 +30,7 @@ class ZeroMessagesStateView: UIView {
 
     private lazy var imageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.image = UIImage(systemName: "bubble.fill")
+        imageView.image = UIImage(systemName: "message.fill")
         imageView.tintColor = .gray
         imageView.translatesAutoresizingMaskIntoConstraints = false
         return imageView


### PR DESCRIPTION
## Summary:
Added Navigation bar items for `MessagesListViewController` along with minor UI enhancements:

- Added left bar buttons and right bar buttons for `MessagesListViewController`
- Updated `arrowImageView` on `MessageCategoryView` to use a more appropriate image
- Updated imageView on `ZeroMessagesStateView` to use a more appropriate image

## Testing:

Navigation bar items & zero state image updates

<img width="250" height="500" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-15 at 17 53 00" src="https://github.com/user-attachments/assets/1fc0260d-82c9-43f2-91ec-d11e17a2269f" />


